### PR TITLE
Mainpage 디자인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "embla-carousel-react": "^8.0.0",
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18",
@@ -2484,6 +2485,31 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.689.tgz",
       "integrity": "sha512-GatzRKnGPS1go29ep25reM94xxd1Wj8ritU0yRhCJ/tr1Bg8gKnm6R9O/yPOhGQBoLMZ9ezfrpghNaTw97C/PQ==",
       "dev": true
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.0.tgz",
+      "integrity": "sha512-ecixcyqS6oKD2nh5Nj5MObcgoSILWNI/GtBxkidn5ytFaCCmwVHo2SecksaQZHcARMMpIR2dWOlSIdA1LkZFUA=="
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.0.0.tgz",
+      "integrity": "sha512-qT0dii8ZwoCtEIBE6ogjqU2+5IwnGfdt2teKjCzW88JRErflhlCpz8KjWnW8xoRZOP8g0clRtsMEFoAgS/elfA==",
+      "dependencies": {
+        "embla-carousel": "8.0.0",
+        "embla-carousel-reactive-utils": "8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.0.0.tgz",
+      "integrity": "sha512-JCw0CqCXI7tbHDRogBb9PoeMLyjEC1vpN0lDOzUjmlfVgtfF+ffLaOK8bVtXVUEbNs/3guGe3NSzA5J5aYzLzw==",
+      "peerDependencies": {
+        "embla-carousel": "8.0.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "embla-carousel-react": "^8.0.0",
     "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -12,8 +12,8 @@ import { usePageStore } from '@/store/scroll-page'
 
 const scrollItemList = [
   { page: <TitlePage />, key: ScrollPageDB[0] },
-  { page: <DetailPage />, key: ScrollPageDB[1] },
-  { page: <ActivityPage />, key: ScrollPageDB[2] },
+  { page: <ActivityPage />, key: ScrollPageDB[1] },
+  { page: <DetailPage />, key: ScrollPageDB[2] },
   { page: <SubmitPage />, key: ScrollPageDB[3] },
 ]
 

--- a/src/components/main/activity-card.tsx
+++ b/src/components/main/activity-card.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+interface ActivityCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string
+}
+
+export const ActivityCard = React.forwardRef<HTMLDivElement, ActivityCardProps>(
+  ({ title }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className="w-[280px] h-80 py-2.5 bg-zinc-900 rounded-[3px] flex-col justify-end items-center gap-2.5 inline-flex"
+      >
+        <div className="justify-center items-center inline-flex">
+          <div className="text-center text-zinc-200 text-2xl font-semibold font-['Inter'] uppercase">
+            {title}
+          </div>
+        </div>
+      </div>
+    )
+  },
+)
+
+ActivityCard.displayName = 'ActivityCard'

--- a/src/components/main/activity-nav-bar.tsx
+++ b/src/components/main/activity-nav-bar.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react'
+
+export function ActivityNavBar() {
+  const [activeIndex, setActiveIndex] = useState<number>(0)
+
+  const handleClick = useCallback((index: number) => {
+    setActiveIndex(index)
+  }, [])
+
+  const renderDots = () => {
+    const dots: JSX.Element[] = []
+
+    for (let i = 0; i < 14; i++) {
+      const dotClasses = `w-2 h-2 rounded cursor-pointer ${
+        i === activeIndex ? 'bg-neutral-500' : 'bg-zinc-400'
+      }`
+
+      dots.push(
+        <div key={i} className={dotClasses} onClick={() => handleClick(i)} />,
+      )
+    }
+
+    return dots
+  }
+
+  return (
+    <section className="py-2 justify-center items-center gap-2 inline-flex">
+      {renderDots()}
+    </section>
+  )
+}

--- a/src/components/main/activity-page.tsx
+++ b/src/components/main/activity-page.tsx
@@ -1,7 +1,20 @@
+import { ActivityNavBar } from '@/components/main/activity-nav-bar'
+import { ActivityViewer } from '@/components/main/activity-viewer'
+
 export default function ActivityPage() {
   return (
-    <div className="flex h-full items-center justify-center bg-red-400">
-      ActivityPage
+    <div className="w-full h-[751px] py-[150px] bg-white flex-col justify-center items-center gap-2.5 inline-flex">
+      <div className="w-[1346px] h-[451px] flex-col justify-center items-center gap-2.5 inline-flex">
+        <div className="self-stretch h-[403px] flex-col justify-center items-center gap-5 flex">
+          <div className="justify-center items-start inline-flex">
+            <div className="text-slate-900 text-4xl font-bold font-['Sen'] leading-[48px]">
+              2023 하반기 HAEDAL 활동
+            </div>
+          </div>
+          <ActivityViewer />
+        </div>
+        <ActivityNavBar />
+      </div>
     </div>
   )
 }

--- a/src/components/main/activity-viewer.tsx
+++ b/src/components/main/activity-viewer.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { ActivityCard } from '@/components/main/activity-card'
+
+export function ActivityViewer() {
+  const activityTitles = ['트랙', '해커톤', '부트캠프', '아이디어톤']
+
+  return (
+    <div className="p-3 justify-center items-center gap-5 flex">
+      {activityTitles.map((title, index) => (
+        <ActivityCard key={index} title={title} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,262 @@
+'use client'
+
+import * as React from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { ArrowLeftIcon, ArrowRightIcon } from '@radix-ui/react-icons'
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from 'embla-carousel-react'
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: 'horizontal' | 'vertical'
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error('useCarousel must be used within a <Carousel />')
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = 'horizontal',
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === 'horizontal' ? 'x' : 'y',
+      },
+      plugins,
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext],
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on('reInit', onSelect)
+      api.on('select', onSelect)
+
+      return () => {
+        api?.off('select', onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn('relative', className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  },
+)
+Carousel.displayName = 'Carousel'
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          'flex',
+          orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = 'CarouselContent'
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className,
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = 'CarouselItem'
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute  h-8 w-8 rounded-full',
+        orientation === 'horizontal'
+          ? '-left-12 top-1/2 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeftIcon className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = 'CarouselPrevious'
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute h-8 w-8 rounded-full',
+        orientation === 'horizontal'
+          ? '-right-12 top-1/2 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRightIcon className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = 'CarouselNext'
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
> 기존 Mainpage 디자인 PR 이어서 작업했습니다!

## 구현한 내용
- activity 페이지 부분 검은색 div 태그로 넣어놨는데, ui 라이브러리 사용해서 더 develop 해보겠습니다.
- 피드백에서 제안했던 것 처럼 mainpage의 전체적인 순서를 수정했습니다.
- 최대한 컴포넌트화 하는 방식으로 코드를 작성했으며, 각 페이지의 기준이 되는 activity-page, detail-page, submit-page, title-page에는 html 관련 코드만 작성하여 최대한 보기 편하게 작성했습니다.